### PR TITLE
Add support for device code link

### DIFF
--- a/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/lib/Driver/ToolChains/CommonArgs.cpp
@@ -1382,7 +1382,7 @@ void tools::AddHIPLinkerScript(const ToolChain &TC, Compilation &C,
   // Get the HIP offload tool chain.
   auto *HIPTC = static_cast<const toolchains::CudaToolChain *>(
       C.getSingleOffloadToolChain<Action::OFK_HIP>());
-  assert(HIPTC->getTriple().getArch() == llvm::Triple::amdgcn &&
+  assert(HIPTC->getTriple().getArch() == llvm::Triple::spir64 &&
          "Wrong platform");
   (void)HIPTC;
 


### PR DESCRIPTION
Hello,

This pull request enables device code linking by:
 - fixing a triple check that hadn't been updated
 - working around a `llvm-link` issue (feature?) that resulted in only the first bitcode object to have it's symbols preserved.

This enables https://github.com/cpc/hipcl/pull/32

Leveraging these features requires setting certain flags on the compile and link lines:
https://github.com/Kerilk/hipcl/blob/d1ba3a0cf5970d1e1c7549ecf361aedb0c901815/samples/CMakeLists.txt#L67-L75

Thanks,
Brice